### PR TITLE
Delete score.error property cause Grafana logs it as error when JSON

### DIFF
--- a/src/modules/gitcoin-claimer/GitcoinClaimer.ts
+++ b/src/modules/gitcoin-claimer/GitcoinClaimer.ts
@@ -135,6 +135,11 @@ class GitcoinAPI {
     }
 
     const score = (await response.json()) as ScoreResponse;
+    // Delete error property if it's null
+    // Since it's being recognized by Grafana as error log
+    if (score.error == null) {
+      delete score.error;
+    }
 
     ServiceManager.GetService(FaucetProcess).emitLog(
       FaucetLogLevel.INFO,


### PR DESCRIPTION
Delete `score.error` if it's `null`, cause Grafana logs recognize its JSON as error log.